### PR TITLE
Update NPM package workflow

### DIFF
--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -31,12 +31,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
+          cache: "npm"
 
       - id: semver
         run: |
@@ -45,17 +47,21 @@ jobs:
             # No manual input, we must be running on a tag
             SEMVER="${GITHUB_REF/refs\/tags\/v/}"
           fi
-          echo "::set-output name=semver::${SEMVER}"
+          echo "semver=${SEMVER}" >> $GITHUB_OUTPUT
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
+      - name: Enable Corepack
         run: |
-          npm --version
-          npm install -g npm@10.9.8
-          npm install -g npm@latest
-      - run: npm ci
-      - run: npm version --no-git-tag-version "${{ steps.semver.outputs.semver }}"
-      - run: npm run build
+          corepack enable
+          corepack prepare npm@latest --activate
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set Version
+        run: npm version --no-git-tag-version "${{ steps.semver.outputs.semver }}"
+
+      - name: Build
+        run: npm run build
 
       - name: Publish
         run: |
@@ -67,4 +73,4 @@ jobs:
               RELEASE_TAG=latest
             fi
           fi
-          npm publish --tag "$RELEASE_TAG" --access public
+          npm publish --tag "$RELEASE_TAG" --access public --provenance

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,18 +11,22 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
           cache: "npm"
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare npm@latest --activate
+
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
-      - run: npm run test -- --coverage
+
+      - name: Run Tests
+        run: npm run test -- --coverage


### PR DESCRIPTION
Improvements:

- Update actions: Checkout & Setup-node to v6
- Setup-node v6:  enables usar of .nvmrc file to set node version. 
- Setup-node v6:  Manages npm cache.
- [Corepack](https://github.com/nodejs/corepack#readme) usage: Enable corepack to use a specific npm version without installing multiple versions (latest in this case).
- [provenance](https://docs.npmjs.com/generating-provenance-statements) flag on publish as a security addition. 
- replace [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) set-output command.